### PR TITLE
Loosen Python interpreter requirements to allow for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 include = ["topt/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.8"
 jax = ">=0.4.26"
 jaxlib = ">=0.4.26"
 cyipopt = ">=1.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 include = ["topt/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 jax = ">=0.4.26"
 jaxlib = ">=0.4.26"
 cyipopt = ">=1.4.1"


### PR DESCRIPTION
I have a repo that must use Python 3.9. `examples/pi_pulse.py` runs with this change so I think it should be fine.